### PR TITLE
h3のunderlineを削除

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -67,7 +67,6 @@ h2 {
 }
 
 h3 {
-  border-bottom: solid 1px var(--color-gray);
   padding-bottom: 4px;
   margin: 30px 0;
 }


### PR DESCRIPTION
hugoではh2,h3のフォントサイズが同じでh2とh3の違いがわかりずらかったので