### PR TITLE
前/次の記事ボタンの表示崩れを修正

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -43,6 +43,7 @@ a {
 /* 記事末尾の「次の記事ボタン」「前の記事ボタン」のスタイル */
 .button.next,.button.previous{
     border: 0;
+    max-width: 100%;
 }
 
 .button a {


### PR DESCRIPTION
モバイルだと崩れるので修正
|before|after|
|---|---|
|<img width="448" alt="image" src="https://github.com/kyu08/blog/assets/49891479/e240fa27-fcc4-414d-a8e6-9661da75aaef">|<img width="451" alt="image" src="https://github.com/kyu08/blog/assets/49891479/07f706eb-21da-4bce-9a2a-738a0fa6d3a7">|