### PR TITLE
リンクを新しいタブで開くように変更

### DIFF
--- a/layouts/partials/extended_head.html
+++ b/layouts/partials/extended_head.html
@@ -1,3 +1,4 @@
+<base target="_blank">
 {{ if not .Site.IsServer }}
 {{ with .Site.GoogleAnalytics }}
 <!-- Google tag (gtag.js) -->


### PR DESCRIPTION
close #95 
https://www.eddymens.com/blog/how-to-make-a-markdown-link-open-in-another-tab

ここで紹介されていた