### PR TITLE
外部リンクのみ新しいタブで開くように修正

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,0 +1,1 @@
+<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if or (strings.HasPrefix .Destination "http") (strings.HasPrefix .Destination "https") }} target="_blank"{{ end }} >{{ .Text | safeHTML }}</a>


### PR DESCRIPTION
https://digitaldrummerj.me/hugo-links-to-other-pages/

`layouts/_default"s"/_markup/render-link.html`ではなく`layouts/_default/_markup/render-link.html`にこの記事で紹介されてたコードを書いたらいけた