### PR TITLE
`git-fork-clone`の`--depth=1`を`--filter=blob:none`に変更

### DIFF
--- a/content/posts/gh-repo-fork-script/index.md
+++ b/content/posts/gh-repo-fork-script/index.md
@@ -43,7 +43,7 @@ function git-fork-clone() {
     echo "🐙 ${REPO} will be forked and cloned.\\n"
     # -- 以降のオプションはgit cloneに渡される
     # See: https://cli.github.com/manual/gh_repo_fork
-    gh repo fork ${REPO} --default-branch-only --clone=true -- --depth=1
+    gh repo fork ${REPO} --default-branch-only --clone=true -- --filter=blob:none
 }
 alias gf=git-fork-clone
 ```


### PR DESCRIPTION
`--depth=1`だとコミット履歴が取得できない。コミット履歴を取得しつつblobは取得しない軽量なオプションである`--filter=blob:none`におきかえた。
see: https://github.blog/jp/2021-01-13-get-up-to-speed-with-partial-clone-and-shallow-clone/