### PR TITLE
`#`同士の間隔を狭める + h2-h6要素の下マージンを小さくする

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -86,6 +86,7 @@ h2, h3, h4, h5, h6 {
 h2 {
   border-bottom: solid 2px var(--color-gray);
   padding-bottom: 4px;
+  margin-bottom: 10px;
 }
 
 h3 {
@@ -139,9 +140,19 @@ article.on-list {
 
 ul {
   margin-top: 30px;
+  margin-bottom: 30px;
+}
+
+ul ul {
+  margin-bottom: 0px;
 }
 
 ol {
+  margin-top: 30px;
+  margin-bottom: 30px;
+}
+
+ol ol {
   margin-bottom: 0px;
 }
 


### PR DESCRIPTION
## 修正前
こういうケースで`#`同士の横方向の間隔の広さとh2とh3とpの間隔の広さが気になったので修正
<img width="1914" height="722" alt="CleanShot 2025-10-25 at 20 01 53@2x" src="https://github.com/user-attachments/assets/e5d727b2-a6d7-4305-bff3-ed9ab0db0467" />

## 修正後
<img width="1914" height="722" alt="CleanShot 2025-10-25 at 20 03 52@2x" src="https://github.com/user-attachments/assets/2d94912c-bb66-4510-93ff-30e4eec0db62" />
