### PR TITLE
style: `p`, `ul`のマージンを減らす

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -94,7 +94,7 @@ h3 {
 }
 
 p {
-  margin-top: 5px;
+  margin: 10px 0;
 }
 
 .post-cover, a.read-more {
@@ -139,8 +139,8 @@ article.on-list {
 }
 
 ul {
-  margin-top: 30px;
-  margin-bottom: 30px;
+  margin-top: 10px;
+  margin-bottom: 10px;
 }
 
 ul ul {
@@ -148,8 +148,8 @@ ul ul {
 }
 
 ol {
-  margin-top: 30px;
-  margin-bottom: 30px;
+  margin-top: 10px;
+  margin-bottom: 10px;
 }
 
 ol ol {


### PR DESCRIPTION
## Before
<img width="1872" height="480" alt="CleanShot 2025-11-02 at 11 35 24@2x" src="https://github.com/user-attachments/assets/394ea372-1542-4f9e-a7e3-7e959b746bfa" />

## After
<img width="1872" height="480" alt="CleanShot 2025-11-02 at 11 34 47@2x" src="https://github.com/user-attachments/assets/df86560a-ae93-4b53-8720-01049544a321" />

