### PR TITLE
hugo: `hugo serve`時に`node_modules`と`.git`をignore

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -6,6 +6,7 @@ languageCode = "ja"
 defaultContentLanguage = "ja"
 hasCJKLanguage = true
 googleAnalytics = "G-BDQ408J45J"
+ignoreFiles = ["node_modules", "\\.git"]
 
 [params]
   # dir name of your main content (default is `content/posts`).


### PR DESCRIPTION
ローカルでhugo serve -wしながら記事を書いてるとなんかだんだんPCが重くなってくる問題を解決したく、試す。