### PR TITLE
hugo: `hugo serve`時にignoreするディレクトリを正規表現を使って指定

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -6,7 +6,10 @@ languageCode = "ja"
 defaultContentLanguage = "ja"
 hasCJKLanguage = true
 googleAnalytics = "G-BDQ408J45J"
-ignoreFiles = ["node_modules", "\\.git"]
+ignoreFiles = [
+  "^.*/node_modules/.*$",
+  "^.*/\\.git/.*$"
+]
 
 [params]
   # dir name of your main content (default is `content/posts`).


### PR DESCRIPTION
## TODO
- [ ] AIレビュー
- [ ] セルフレビュー
	- [ ] markdownが期待通りにレンダリングされているかチェック
	- [ ] 誤字脱字チェック
	- [ ] 読みづらいところがないかチェック
	- [ ] TODOが残ってないかチェック
	- [ ] textlintの指摘で直したいところがあれば修正
	- [ ] 技術的に不正確/不明瞭な記述がないかチェック

<!-- AIレビュー用プロンプト

以下の文章を次の観点でレビューしてください。
- 誤字脱字がないか
- 固有名詞を間違えていないか
- 読みづらい箇所がないか
- 間違った記述がないか
- 不用意な断定がないか
```md

```

-->
