### PR TITLE
fix: build error of blogcard

### DIFF
--- a/layouts/partials/blogcard.html
+++ b/layouts/partials/blogcard.html
@@ -5,7 +5,7 @@
 {{- $autoFetch := .autoFetch | default "true" -}}
 
 {{- /* キャッシュデータを確認 */ -}}
-{{- $cachedData := nil -}}
+{{- $cachedData := false -}}
 {{- if site.Data.blogcard_cache -}}
   {{- $cachedData = index site.Data.blogcard_cache $url -}}
 {{- end -}}


### PR DESCRIPTION
```sh
Error: error building site: "/home/runner/work/blog/blog/content/posts/cqrs-documents-by-greg-young/index.md:1:1": "/home/runner/work/blog/blog/layouts/_default/_markup/render-link.html:11:6": execute of template failed: template: _default/_markup/render-link.html:11:6: executing "_default/_markup/render-link.html" at <partial "blogcard.html" (dict "url" $dest "autoFetch" "true")>: error calling partial: "/home/runner/work/blog/blog/layouts/partials/blogcard.html:8:19": execute of template failed: template: partials/blogcard.html:8:19: executing "partials/blogcard.html" at <nil>: nil is not a command
```