### PR TITLE
fix(ci): push前にgit pull --rebaseを追加してCI同時実行時のコンフリクトを防止

### DIFF
--- a/.github/workflows/fetch-blogcard-ogp-on-pr.yaml
+++ b/.github/workflows/fetch-blogcard-ogp-on-pr.yaml
@@ -48,4 +48,5 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git add data/
           git commit -m "chore: update OGP and embed cache"
+          git pull --rebase origin ${{ github.head_ref }}
           git push origin HEAD:${{ github.head_ref }}

--- a/.github/workflows/generate-ogp.yaml
+++ b/.github/workflows/generate-ogp.yaml
@@ -49,6 +49,7 @@ jobs:
           shopt -s globstar
           git add content/**/cover.png static/cover.png 2>/dev/null || true
           git commit -m "chore: update OGP images"
+          git pull --rebase origin ${{ github.head_ref }}
           git push origin HEAD:${{ github.head_ref }}
 
       - name: Check for OGP changes in PR


### PR DESCRIPTION
## Summary
- OGP生成CIとblogcardキャッシュ取得CIが同時に走った際、片方のpushが失敗する問題を修正
- 両ワークフローの `git push` 直前に `git pull --rebase` を追加

## Test plan
- [ ] PRで両CIが同時に走った際にコンフリクトせずpushが成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)