### PR TITLE
feat(scripts): webp変換時にリサイズと200KB以内への圧縮を追加

### DIFF
--- a/scripts/compress-to-webp.sh
+++ b/scripts/compress-to-webp.sh
@@ -14,5 +14,5 @@ for file in "$TARGET"/*.{jpg,jpeg,png,JPG,JPEG,PNG}; do
 
   # NOTE: imagemagickのインストールが必要
   # -auto-orientをつけないと画像の向きが正しくならないことがある
-  magick "$file" -auto-orient -format webp "${file%.*}.webp"
+  magick "$file" -auto-orient -resize "1200x>" -define webp:target-size=204800 -format webp "${file%.*}.webp"
 done


### PR DESCRIPTION
## Summary
- webp変換スクリプトに `-resize "1200x>"` を追加し、横幅1200px超の画像を自動縮小
- `-define webp:target-size=204800` で出力を常に200KB以内に収める

## Test plan
- [ ] 1200px超の画像で変換し、出力が200KB以内かつアスペクト比が維持されることを確認
- [ ] 1200px以下の画像で変換し、リサイズされないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)