### PR TITLE
画像のキャプション表示機能を追加

### DIFF
--- a/content/posts/vim-conf-2025/index.md
+++ b/content/posts/vim-conf-2025/index.md
@@ -18,7 +18,7 @@ cover: cover.png
 
 2025年11月2日（日）にアキバプラザ・アキバホールで開催された[VimConf 2025 Small](https://vimconf.org/2025/ja/)に参加した。
 
-![vim-conf-2025.webp](vim-conf-2025.webp "test")
+![vim-conf-2025.webp](vim-conf-2025.webp)
 
 こちらはノベルティ。食器とかお箸はたくさんあっても困らないのでありがたい。
 

--- a/content/posts/vim-conf-2025/index.md
+++ b/content/posts/vim-conf-2025/index.md
@@ -18,7 +18,7 @@ cover: cover.png
 
 2025年11月2日（日）にアキバプラザ・アキバホールで開催された[VimConf 2025 Small](https://vimconf.org/2025/ja/)に参加した。
 
-![vim-conf-2025.webp](vim-conf-2025.webp)
+![vim-conf-2025.webp](vim-conf-2025.webp "test")
 
 こちらはノベルティ。食器とかお箸はたくさんあっても困らないのでありがたい。
 

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,0 +1,14 @@
+{{- /* 画像をfigure要素で囲み、title属性をキャプションとして表示 */ -}}
+{{- /* Markdown: ![alt](src "caption") の "caption" 部分が figcaption になる */ -}}
+{{- $alt := .Text -}}
+{{- $src := .Destination -}}
+{{- $caption := .Title -}}
+
+{{- if $caption -}}
+  <figure class="image-with-caption">
+    <img src="{{ $src | safeURL }}" alt="{{ $alt }}" loading="lazy" />
+    <figcaption>{{ $caption }}</figcaption>
+  </figure>
+{{- else -}}
+  <img src="{{ $src | safeURL }}" alt="{{ $alt }}" loading="lazy" />
+{{- end -}}

--- a/static/style.css
+++ b/static/style.css
@@ -130,6 +130,25 @@ img {
   margin: 0;
 }
 
+/* 画像キャプションのスタイル */
+figure.image-with-caption {
+  margin: 20px 0;
+  text-align: center;
+}
+
+figure.image-with-caption img {
+  display: block;
+  margin: 0 auto;
+  border: none;
+}
+
+figure.image-with-caption figcaption {
+  margin-top: 8px;
+  font-size: 0.9em;
+  color: var(--color-gray);
+  font-style: italic;
+}
+
 /* 動画のレスポンシブ対応 */
 figure.video {
   width: 100%;

--- a/static/style.css
+++ b/static/style.css
@@ -143,10 +143,11 @@ figure.image-with-caption img {
 }
 
 figure.image-with-caption figcaption {
-  margin-top: 8px;
   font-size: 0.9em;
   color: var(--color-gray);
   font-style: italic;
+  background: transparent;
+  border-radius: 0;
 }
 
 /* 動画のレスポンシブ対応 */


### PR DESCRIPTION
## Description

画像キャプション機能を追加する。標準Markdown構文 `![alt](src "caption")` の **title 部分** を `<figcaption>` として描画する。

## なぜこの方式か

- `alt` と `caption` は役割が違う。alt はスクリーンリーダー向けの代替テキスト、caption は閲覧者全員に見せる補足情報。
- 同じ文字列を両方に入れるとスクリーンリーダーで二重に読み上げられる懸念があり、WAI-ARIAの推奨（figcaptionで内容を伝えるなら `alt=""` にする）にも反する。
- `![alt](src "caption")` は標準Markdownの範囲内で、他のレンダラー（GitHub等）でも崩れない。

## Changes

### `layouts/_default/_markup/render-image.html`（新規）

Hugoのimage render hookを実装。`title` の有無で分岐する。

| Markdown | 出力 |
| --- | --- |
| `![A](src "B")` | `<figure class="image-with-caption">` + `<img alt="A">` + `<figcaption>B</figcaption>` |
| `![A](src)` | `<img alt="A">` のみ |

`title` が指定されていなければ通常の `<img>` のままなので、既存記事の表示は変わらない（後方互換）。

### `static/style.css`

`figure.image-with-caption` のスタイルを追加。キャプションは画像下にイタリック・グレー文字で中央寄せ。

テーマ `themes/terminal/assets/css/terminal.css` 側の `figure figcaption { background: var(--accent); border-radius: ...; }` を打ち消すため、`background: transparent;` と `border-radius: 0;` を明示している。

## Usage

```markdown
![EarPodsを外したデスク](desk.webp "執筆環境のデスク。EarPodsを外して使用")
```

## Screenshot

画像下にキャプションが表示される:
<img width="2100" height="1378" alt="CleanShot 2026-04-29 at 17 09 54@2x" src="https://github.com/user-attachments/assets/914300ab-43a7-4f42-95d7-e1567ec268c5" />

